### PR TITLE
Add "1" as a true Boolean value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const types = {
   },
   boolean: {
     test: _.isBoolean,
-    cast: (val) => (val === 'true'),
+    cast: (val) => (val === 'true' || val === '1'),
   },
   array: {
     test: _.isArray,


### PR DESCRIPTION
At the moment only `"true"` will be considered a castable boolean to `true`. But `"1"` should be valid too.